### PR TITLE
Fixed incorrect Alacritty instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ After that, you can get the theme from specific directories for supported termin
 [See Below](#alacritty)
 
 ### [Alacritty](https://github.com/alacritty/alacritty) -
-Head over to `alacritty/` and copy `decay.json` to your alacritty config path:
+Head over to `alacritty/` and copy `decay.yml` to your alacritty config path:
 
 ```sh
 cd decay-terms/alacritty


### PR DESCRIPTION
Alacritty uses `.yml` files, as the rest of the instructions state, so I've removed an incorrect reference to a `.json` file